### PR TITLE
Add version 6.12, 7.4 and HEADCS to tests in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,10 @@ env:
     - RACKET_VERSION: 6.4
     - RACKET_VERSION: 6.5
     - RACKET_VERSION: 6.6
+    - RACKET_VERSION: 6.12
+    - RACKET_VERSION: 7.4
     - RACKET_VERSION: HEAD
+    - RACKET_VERSION: HEADCS
 
 before_install:
   - git clone https://github.com/greghendershott/travis-racket.git


### PR DESCRIPTION
Add version 6.12, 7.4 and HEADCS to tests in travis-ci.

I added the version 6.12 because it's the last of the 6.? serie. I can add the versions between 6.6 and 6.12 if you prefer it.

I skipped the version 7.0, 7.1, 7.2 and 7.3 because the expander had a few minor incompatibilities that has been fixed in 7.4.