### PR TITLE
Fixes reading of characters in the REPL

### DIFF
--- a/r7rs-lib/lang/private/char.rkt
+++ b/r7rs-lib/lang/private/char.rkt
@@ -21,9 +21,10 @@
     ; read-syntax
     [(c in src line col pos)
      (parameterize ([current-source src])
-       (let* ([datum (read-char-literal c in)]
+       (let* ([start-pos (file-position in)]
+              [datum (read-char-literal c in)]
               [final-pos (file-position in)])
-         (datum->syntax #f datum (list src line col pos (- final-pos pos)))))]))
+         (datum->syntax #f datum (list src line col pos (- final-pos start-pos)))))]))
 
 (define (peek-alphabetic? port)
   (let ([c (peek-char port)])


### PR DESCRIPTION
Fixes issue #18 

I tested both literal characters in the definitions window and in the REPL, both are working now. I didn't test it properly but it seems to fix the linked issue.