### PR TITLE
Bug fix on records with 4 or more modifiers

### DIFF
--- a/r7rs-lib/lang/private/char.rkt
+++ b/r7rs-lib/lang/private/char.rkt
@@ -21,9 +21,10 @@
     ; read-syntax
     [(c in src line col pos)
      (parameterize ([current-source src])
-       (let* ([datum (read-char-literal c in)]
+       (let* ([start-pos (file-position in)]
+              [datum (read-char-literal c in)]
               [final-pos (file-position in)])
-         (datum->syntax #f datum (list src line col pos (- final-pos pos)))))]))
+         (datum->syntax #f datum (list src line col pos (- final-pos start-pos)))))]))
 
 (define (peek-alphabetic? port)
   (let ([c (peek-char port)])

--- a/r7rs-lib/private/record.rkt
+++ b/r7rs-lib/private/record.rkt
@@ -82,7 +82,7 @@
                (values struct:record make-record record-pred?
                        (make-struct-field-accessor record-ref field-index 'field-accessors)
                        ...
-                       (make-struct-field-mutator record-set! field-modifier-index 'field-modifiers ...)
+                       (make-struct-field-mutator record-set! field-modifier-index 'field-modifiers)
                        ...)))
            ; wrap the struct constructor with a custom proc that handles missing fields
            (define (constructor.name constructor.field ...)

--- a/r7rs-lib/private/record.rkt
+++ b/r7rs-lib/private/record.rkt
@@ -80,9 +80,9 @@
                            (make-struct-type 'name #f #,(length (current-record-fields))
                                              0 #f '() #f #f '() #f 'constructor.name)])
                (values struct:record make-record record-pred?
-                       (make-struct-field-accessor record-ref field-index 'field-accessors)
+                       (procedure-rename (make-struct-field-accessor record-ref field-index 'name) 'field-accessors)
                        ...
-                       (make-struct-field-mutator record-set! field-modifier-index 'field-modifiers)
+                       (procedure-rename (make-struct-field-mutator record-set! field-modifier-index 'name) 'field-modifiers)
                        ...)))
            ; wrap the struct constructor with a custom proc that handles missing fields
            (define (constructor.name constructor.field ...)


### PR DESCRIPTION
This pull request fixes an issue with record definitions that have 4 or more modifiers defined within them.

```
#lang r7rs
(import (scheme base))
(define-record-type test
  (make a b c d)
  test?
  (a get-a a!)
  (b get-b b!)
  (c get-c c!)
  (d get-d d!))
```

This program currently raises the following error:

```
make-struct-field-mutator: arity mismatch;
 the expected number of arguments does not match the given number
  given: 6
```

Upon investigation in `r7rs-lib/private/records.rkt`, I identified that the call to `make-struct-field-mutator` (which generates the mutator procedure) contains an expansion of `'field-modifiers` in such a way that when there are more modifiers, `make-struct-field-mutator` is called with too many arguments. From what I can tell, from reading the documentation on `make-struct-field-mutator`, only the name of the modifier that is to be generated has to be supplied. This commit does exactly that.

I haven't yet fully tested whether this breaks other parts, but it seems to be correct to get the small example program listed above to work.

Tagging @svdvonde and @endymion64 (who provided the example code above), who raised this issue to me.